### PR TITLE
fix some characterset weirdness in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wristspasm-reborn",
   "version": "1.0.0",
-  "description": "��#\u0000 \u0000W\u0000r\u0000i\u0000s\u0000t\u0000S\u0000p\u0000a\u0000s\u0000m\u0000-\u0000R\u0000e\u0000b\u0000o\u0000r\u0000n\u0000\r\u0000 \u0000",
+  "description": "WristSpasm Reborn",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Your package.json got a little bit messed up:

```
��#\u0000 \u0000W\u0000r\u0000i\u0000s\u0000t\u0000S\u0000p\u0000a\u0000s\u0000m\u0000-\u0000R\u0000e\u0000b\u0000o\u0000r\u0000n\u0000\r\u0000 \u0000
```

Gonna guess thats because of some weird UTF-16 windows stuff.
Anyways, patched it up with what it looks like the text is supposed to be (`WristSpasm Reborn`).